### PR TITLE
Loosen the semver requirements for the front-end engines

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,8 +92,8 @@
     "webpack-merge": "^4.1.0"
   },
   "engines": {
-    "node": "8.1.4",
-    "yarn": "0.27.5"
+    "node": "^8.1.4",
+    "yarn": ">=0.27.5"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
I've got a more recent version of yarn + node locally.  Which means that yarn complains whenever I try to do anything yarn.  Note: this is not a blocker because adding the `--ignore-engines` flag lets me bypass the engines semver.

But regularly needing to use the `--ignore-engines` flag leads me to thinking that either

1. I'm missing the point on vagrant, and I should be developing _within_ the vagrant environment where the engine version is controlled.

or

2. We can loosen the engine requirements

With respect to the semver changes, upgraded minor versions of node should be fine.  And I ran a yarn install and it worked locally (v 1.1.0) without rewriting the entire yarn.lock file, so it seems unlikely a newer version would cause any issues.  Maybe I should bound the yarn.lock file at `<=2.0.0`?

Thoughts @ryankanno , @rbvea ?