### PR TITLE
Add frontend config structure proof of concept

### DIFF
--- a/frontend/build/webpack.base.conf.js
+++ b/frontend/build/webpack.base.conf.js
@@ -1,3 +1,4 @@
+var webpack = require("webpack");
 var path = require("path");
 var utils = require("./utils");
 var config = require("../config");
@@ -26,6 +27,11 @@ module.exports = {
       "@": resolve("src")
     }
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    }),
+  ],
   module: {
     rules: [
       {

--- a/frontend/src/components/Admin.vue
+++ b/frontend/src/components/Admin.vue
@@ -87,9 +87,9 @@
 
       </md-layout>
     </md-layout>
-    
-    <md-layout md-flex="65" class="page-content map">      
-    </md-layout>   
+
+    <md-layout md-flex="65" class="page-content map">
+    </md-layout>
   </md-layout>
 </div>
 </template>
@@ -106,9 +106,9 @@ import "mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
 // import Vue from 'vue'
 import MapboxDraw from "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+import config from "@/config";
 
-Mapbox.accessToken =
-  "pk.eyJ1IjoicnVzc2VsbHZlYTIiLCJhIjoiY2lmZzVrNWJkOWV2cnNlbTdza2thcGozNSJ9.zw6CcZLxP6lq0x-xfwp6uA";
+Mapbox.accessToken = config.API_TOKEN;
 
 export default {
   data: function() {

--- a/frontend/src/components/Map.vue
+++ b/frontend/src/components/Map.vue
@@ -14,6 +14,7 @@
 import Mapbox from "mapbox-gl";
 import { mapState } from "vuex";
 import "mapbox-gl/dist/mapbox-gl.css";
+import config from "@/config";
 
 import Axios from "axios";
 import bottombar from "./BottomBar.vue";
@@ -23,8 +24,7 @@ import topbar from "./TopBar.vue";
 import MapboxGeocoder from "mapbox-gl-geocoder";
 import "mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
 
-Mapbox.accessToken =
-  "pk.eyJ1IjoicnVzc2VsbHZlYTIiLCJhIjoiY2lmZzVrNWJkOWV2cnNlbTdza2thcGozNSJ9.zw6CcZLxP6lq0x-xfwp6uA";
+Mapbox.accessToken = config.API_TOKEN;
 
 export default {
   computed: mapState({
@@ -131,7 +131,7 @@ export default {
     },
     setAllLayers(lng, lat, map) {
       var url =
-        'http://localhost:50050/features/?where={"geojson.geometry":{"$near":{"$geometry":{"type":"Point", "coordinates":[' +
+        `${config.API_URL}/features/?where={"geojson.geometry":{"$near":{"$geometry":{"type":"Point", "coordinates":[` +
         lng +
         ", " +
         lat +
@@ -139,13 +139,13 @@ export default {
       this.getLayerData(url, map);
     },
     /**
-     * @argument 
+     * @argument
      */
     getLayerData(href, map) {
       return Axios.get(href).then(response => {
         this.setLayers(response.data, map);
         if (response.data._links.next) {
-          var url = "http://localhost:50050/" + response.data._links.next.href;
+          var url = `${config.API_URL}/` + response.data._links.next.href;
           return this.getLayerData(url, map);
         }
       });

--- a/frontend/src/components/Rule.vue
+++ b/frontend/src/components/Rule.vue
@@ -31,8 +31,9 @@ import topbar from "./TopBar.vue";
 import { mapState } from "vuex";
 // const locationIcon = require('../assets/location.svg')
 
-Mapbox.accessToken =
-  "pk.eyJ1IjoicnVzc2VsbHZlYTIiLCJhIjoiY2lmZzVrNWJkOWV2cnNlbTdza2thcGozNSJ9.zw6CcZLxP6lq0x-xfwp6uA";
+import config from "@/config";
+
+Mapbox.accessToken = config.API_TOKEN;
 
 export default {
   name: "Rule",

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,23 @@
+// All possible configs for different environments
+const config = {
+  development: {
+    API_URL: "http://localhost:50050"
+  },
+  production: {
+    API_URL: "http://localhost:50050"
+  },
+  default: {
+    API_URL: "http://localhost:50050",
+    API_TOKEN: `
+pk.eyJ1IjoicnVzc2VsbHZlYTIiLCJhIjoiY2lmZzVrNWJkOWV2cnNlbTdza2thcGozNSJ9.zw6CcZLxP6lq0x-xfwp6uA`
+  }
+};
+
+// The selected config (defaults to config.default)
+let selected = config[process.env.NODE_ENV] || config.default;
+
+// Exports the config, filling the possible gaps with config.default
+export default {
+  ...config.default,
+  ...selected
+};


### PR DESCRIPTION
Sorry for the massive delay on this!

I've did a little more than #59 , by adding some kind of infrastructure to add more variables there (an example can be found for `Mapbox.accessToken`).

In short terms, what's being done here is:

- Bypass `process.env.NODE_ENV` from `node`, through `webpack` to the browser.
- Use `process.env.NODE_ENV` on `frontend/src/config.js` to generate objects with the desired config variables/keys
- Using `import config from "@/config";` to replace the occurrences of the previous variables from the `config` - a unified source.