### PR TITLE
Update instructions and docker compose to include local mongodb

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,17 +3,17 @@
 ## Requirements
 
 * Docker ([Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac); Linux :neckbeard:)
-* [jq](https://stedolan.github.io/jq/)
-* [httpie](https://httpie.org/)
+* [jq](https://stedolan.github.io/jq/) -- for jq command
+* [httpie](https://httpie.org/) -- for http command
+* [gdal](https://gdal.org/) -- for ogr2ogr command
 * Python 2.7.9
 
 ## Running
 
 As a note, to run the database, you need a .env file in this directory that
 contains the database environment variables. Please ask someone in the channel
-#cfh-aclu for the file. We do know that there is an extraneous Mongo db image
-currently in the docker-compose script, but we kept it around for s-giggles in
-the case that someone wants to run Mongo locally.
+#cfh-aclu for the file. If you want to run mongodb locally, uncomment the
+mongo image settings to use the bitnami mongodb image.
 
 ```
 $ make dev
@@ -25,6 +25,21 @@ $ curl http://localhost:50050/aloha
 Please see the [data schema](Schema.md) for more details.
 
 # Common tasks
+
+## Environment variables
+
+Many of the commands and files below assume that the following environment
+variables are set:
+
+* MONGO_HOST (use aclu-db to match the docker compose container name)
+* MONGO_PORT (27017 should be used)
+* MONGO_USERNAME
+* MONGO_PASSWORD
+* MONGO_DBNAME 
+
+If `MONGO_HOST` or `MONGO_PORT` are not set to `aclu-db` or `27017` respectively
+, you will need to change the docker-compose configs and probably several of the
+scripts in order to get things to run.
 
 ## Converting tmk data to geojson
 
@@ -124,7 +139,7 @@ aclu-api |  planner returned error: unable to find index for $geoNear query
 
 ### Creating the spatial index
 
-```docker exec -it <db_container_id> mongo aclu --eval "db.features.ensureIndex({'geojson.geometry': '2dsphere'})"```
+```docker exec -it <db_container_id> mongo --username ${MONGO_USERNAME} --password ${MONGO_PASSWORD} ${MONGO_DBNAME} --eval "db.features.ensureIndex({'geojson.geometry': '2dsphere'})"```
 
 ### Dropping entire collection
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -15,12 +15,14 @@ services:
       - "50050:50050"
     volumes:
       - ./api:/src/api
-  #   links:
-  #     - db
-  # db:
-  #   image: mongo:3.5.11
-  #   ports:
-  #     - "27017"
-  #   container_name: aclu-db
-  #   logging:
-  #     driver: none
+    links:
+      - db
+#  db:
+#    container_name: aclu-db
+#    image: 'bitnami/mongodb:4.0.9'
+#    ports:
+#      - "27017:27017"
+#    environment:
+#      - MONGODB_USERNAME=${MONGO_USERNAME}
+#      - MONGODB_PASSWORD=${MONGO_PASSWORD}
+#      - MONGODB_DATABASE=${MONGO_DBNAME}

--- a/backend/etc/seed_fake_park_data.sh
+++ b/backend/etc/seed_fake_park_data.sh
@@ -390,7 +390,7 @@ done;
 
 cd "${__dir}/../"
 
-/usr/bin/ogr2ogr -f GeoJSON -t_srs crs:84 \
+ogr2ogr -f GeoJSON -t_srs crs:84 \
 "importer/2017-07-19.parks.geojson" \
 "data/parks/2017.07.19 - Parks__Oahu/Parks__Oahu.shp"
 


### PR DESCRIPTION
Tested instructions and it looks like everything works, I've updated the instructions and config to let users quickly setup a local mongodb instance for dev use. It's commented out by default but can easily be re-enabled.