### PR TITLE
Prevent users from scaling the site.

### DIFF
--- a/frontend-v2/public/index.html
+++ b/frontend-v2/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=0">
 		<link rel="icon" href="<%= BASE_URL %>favicon.ico">
 		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,500,700,400italic|Material+Icons">
     <title>Holo Holo</title>


### PR DESCRIPTION
This should fix an issue where selecting an input in iOS will cause the page to zoom in: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone. This is an easier fix than fidgeting with the font size but we may take another look it for accessibility issues.